### PR TITLE
검색 필터 레이어 노출 방식 변경

### DIFF
--- a/app/assets/javascripts/arctic_admin/base.js
+++ b/app/assets/javascripts/arctic_admin/base.js
@@ -20,7 +20,6 @@ $(function() {
           $(this).animate({
             right: "+="+width
           }, 600, function() {
-            $(this).css('position', 'absolute');
             animationFilterDone = true;
           });
         }


### PR DESCRIPTION
* position 값이 absolute여서 화면 하단에서 필터 버튼을 클릭 시 검색 레이어가 화면 최상단으로 올라가버려 보이지 않는 케이스 발생.